### PR TITLE
fix: 优化首页 meta description，避免搜索结果截断

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,7 @@
   "Metadata": {
     "name": "FlowChart AI",
     "title": "Flowchart AI: Convert Text & Images to editable Flowcharts",
-    "description": "Transform text and images into stunning flowcharts instantly with our advanced Flowchart AI. Convert documents, descriptions, and visuals into professional diagrams in seconds. Free to try!"
+    "description": "Flowchart AI converts text and images into editable flowcharts in seconds. Create, refine, and export professional diagrams online for free."
   },
   "Common": {
     "login": "Log in",


### PR DESCRIPTION
## 摘要
- 将首页默认 `Metadata.description` 从 `189` 字符压缩到 `140` 字符
- 保留 `Flowchart AI`、`text and images`、`editable flowcharts` 等核心价值表达
- 确认首页输出的 `description`、`og:description`、`twitter:description` 三处同步更新

## 验证
- `node - <<'NODE'` 读取 `messages/en.json` 并确认长度为 `140`
- `pnpm exec biome check messages/en.json`
- `pnpm dev` 后执行 `curl -sL http://127.0.0.1:3001/ | rg -o ...` 验证三个 meta 标签

Linear: `TAN-37`
