### PR TITLE
fix: 为首页补充 WebSite 与 Organization JSON-LD

### DIFF
--- a/src/app/[locale]/(marketing)/(home)/page.tsx
+++ b/src/app/[locale]/(marketing)/(home)/page.tsx
@@ -11,12 +11,14 @@ import { HowItWorksSection } from '@/components/blocks/how-it-works';
 import PricingSection from '@/components/blocks/pricing/pricing';
 import { TutorialsSection } from '@/components/blocks/tutorials';
 import { UseCasesSection } from '@/components/blocks/use-cases';
+import { JsonLd } from '@/components/seo/json-ld';
+import { websiteConfig } from '@/config/website';
+import { defaultMessages } from '@/i18n/messages';
 import { constructMetadata } from '@/lib/metadata';
-import { getUrlWithLocale } from '@/lib/urls/urls';
+import { getImageUrl, getUrlWithLocale } from '@/lib/urls/urls';
 import type { Metadata } from 'next';
 import type { Locale } from 'next-intl';
 import { getTranslations } from 'next-intl/server';
-import Script from 'next/script';
 
 /**
  * https://next-intl.dev/docs/environments/actions-metadata-route-handlers#metadata-api
@@ -44,6 +46,25 @@ export default async function HomePage(props: HomePageProps) {
   const params = await props.params;
   const { locale } = params;
   const t = await getTranslations('HomePage');
+  const homePageUrl = getUrlWithLocale('', locale);
+  const organizationLogoUrl = getImageUrl(
+    websiteConfig.metadata.images?.logoLight || '/logo.png'
+  );
+
+  const websiteSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: defaultMessages.Metadata.name,
+    url: homePageUrl,
+  };
+
+  const organizationSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    logo: organizationLogoUrl,
+    name: defaultMessages.Metadata.name,
+    url: homePageUrl,
+  };
 
   const faqSchema = {
     '@context': 'https://schema.org',
@@ -126,6 +147,10 @@ export default async function HomePage(props: HomePageProps) {
 
   return (
     <>
+      <JsonLd data={websiteSchema} id="website-schema" />
+      <JsonLd data={organizationSchema} id="organization-schema" />
+      <JsonLd data={faqSchema} id="faq-schema" />
+
       <div className="flex flex-col">
         <HeroSection />
 
@@ -149,14 +174,6 @@ export default async function HomePage(props: HomePageProps) {
 
         <CallToActionSection />
       </div>
-
-      <Script
-        id="faq-schema"
-        type="application/ld+json"
-        strategy="afterInteractive"
-      >
-        {JSON.stringify(faqSchema)}
-      </Script>
     </>
   );
 }

--- a/src/components/seo/json-ld.tsx
+++ b/src/components/seo/json-ld.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+
+type JsonLdEntry = Record<string, unknown>;
+type JsonLdData = JsonLdEntry | JsonLdEntry[];
+
+interface JsonLdProps {
+  data: JsonLdData;
+  id: string;
+}
+
+function serializeJsonLd(data: JsonLdData): string {
+  return JSON.stringify(data).replace(/</g, '\\u003c');
+}
+
+export function JsonLd({ data, id }: JsonLdProps): ReactElement {
+  return (
+    <script id={id} suppressHydrationWarning type="application/ld+json">
+      {serializeJsonLd(data)}
+    </script>
+  );
+}


### PR DESCRIPTION
## 摘要
- 为首页新增服务端输出的 `WebSite` JSON-LD
- 为首页新增服务端输出的 `Organization` JSON-LD，并补齐 `logo`
- 将现有 FAQ schema 从 `afterInteractive` 改为服务端直出，保证初始 HTML 可见

## 验证
- `pnpm exec biome check 'src/app/[locale]/(marketing)/(home)/page.tsx' src/components/seo/json-ld.tsx`\n- `NEXT_PUBLIC_BASE_URL=https://flowchartai.org pnpm build`\n- 本地抓取首页初始 HTML，确认 `canonical` 与 JSON-LD 字段一致