### PR TITLE
fix: correct broken cookie policy links

### DIFF
--- a/content/pages/cookie-policy.mdx
+++ b/content/pages/cookie-policy.mdx
@@ -166,11 +166,10 @@ Cookies are small text files that are stored on your device (computer, tablet, o
 
 You have several options to manage cookies:
 
-#### 1. Cookie Preference Center
-- Visit our Cookie Settings page: https://flowchartai.org/cookie-settings
-- Toggle different cookie categories on/off
-- View detailed information about each cookie
-- Save your preferences instantly
+#### 1. Cookie Policy and Banner Controls
+- Review our [Cookie Policy](/cookie) for details about the cookies we use
+- Use the cookie banner's "Customize" option to adjust available cookie categories
+- Save your preferences instantly in the banner modal
 
 #### 2. Browser Settings
 **Chrome**: Settings > Privacy and Security > Cookies and other site data
@@ -187,7 +186,7 @@ You have several options to manage cookies:
 ### Withdrawing Consent
 
 You can withdraw your consent at any time by:
-1. **Updating Preferences**: Use our Cookie Settings page
+1. **Updating Preferences**: Use the cookie banner's "Customize" option
 2. **Clearing Cookies**: Delete cookies through your browser
 3. **Contacting Us**: Email support@flowchartai.org
 4. **Re-visiting Banner**: Clear your consent cookie to see the banner again

--- a/content/pages/privacy-policy.mdx
+++ b/content/pages/privacy-policy.mdx
@@ -225,7 +225,7 @@ If you are a parent or guardian and believe your child has provided us with pers
 
 ## Cookies and Tracking
 
-We use cookies and similar technologies to enhance your experience. For detailed information about our cookie practices, please see our [Cookie Policy](/cookie-policy).
+We use cookies and similar technologies to enhance your experience. For detailed information about our cookie practices, please see our [Cookie Policy](/cookie).
 
 ### Essential Cookies
 - Session management and authentication


### PR DESCRIPTION
## 摘要
- 修复隐私政策页面中 `Cookie Policy` 锚文本错误指向不存在 `/cookie-policy` 的问题
- 修复 Cookie Policy 页面中错误的 `cookie-settings` 文案与链接，只保留真实存在的 `/cookie` 页面和实际可用的 Cookie banner 控制方式

## 验证
- `rg -n "cookie-settings|/cookie-policy" content/pages src`
- `pnpm build`
- `PORT=3100 pnpm start`
- `curl -s -L -o /tmp/tan148-privacy.html -w "%{http_code}" http://127.0.0.1:3100/en/privacy`
- `curl -s -L -o /tmp/tan148-cookie.html -w "%{http_code}" http://127.0.0.1:3100/en/cookie`
- `rg -n "Cookie Policy|href="/cookie"" /tmp/tan148-privacy.html`

Linear: TAN-148