### PR TITLE
feat: add IndexNow submission tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "test-cdn": "node scripts/test-cdn.js",
+    "indexnow:submit": "tsx scripts/submit-indexnow.ts",
     "migrate-assets": "node scripts/migrate-assets.js",
     "update-asset-paths": "node scripts/update-asset-paths.js",
     "test-cdn-resources": "node scripts/test-cdn-resources.js",

--- a/scripts/submit-indexnow.ts
+++ b/scripts/submit-indexnow.ts
@@ -1,0 +1,238 @@
+import {
+  INDEXNOW_ENDPOINT,
+  INDEXNOW_KEY,
+  extractRobotsDirectives,
+  getIndexNowKeyLocation,
+  hasBlockingRobotsDirective,
+  normalizeBaseUrl,
+  parseSitemapUrls,
+} from '../src/lib/seo/indexnow';
+
+type CliOptions = {
+  baseUrl: string;
+  dryRun: boolean;
+  endpoint: string;
+  sitemapUrl?: string;
+};
+
+type InspectionResult = {
+  directives: string[];
+  reason?: string;
+  url: string;
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    baseUrl:
+      process.env.INDEXNOW_BASE_URL ??
+      process.env.NEXT_PUBLIC_BASE_URL ??
+      'https://flowchartai.org',
+    dryRun: false,
+    endpoint: INDEXNOW_ENDPOINT,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (arg === '--base-url') {
+      options.baseUrl = readArgValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--sitemap-url') {
+      options.sitemapUrl = readArgValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--endpoint') {
+      options.endpoint = readArgValue(argv, index, arg);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function readArgValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1];
+
+  if (!value) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+async function fetchText(url: string): Promise<string> {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'FlowChartAI-IndexNow/1.0',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status}`);
+  }
+
+  return response.text();
+}
+
+async function inspectUrl(
+  url: string,
+  expectedHost: string
+): Promise<InspectionResult> {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'FlowChartAI-IndexNow/1.0',
+    },
+    redirect: 'follow',
+  });
+
+  if (!response.ok) {
+    return {
+      directives: [],
+      reason: `status:${response.status}`,
+      url,
+    };
+  }
+
+  const finalUrl = new URL(response.url);
+
+  if (finalUrl.host !== expectedHost) {
+    return {
+      directives: [],
+      reason: `redirect-host:${finalUrl.host}`,
+      url,
+    };
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  const html =
+    contentType.includes('text/html') ||
+    contentType.includes('application/xhtml+xml')
+      ? await response.text()
+      : undefined;
+  const directives = extractRobotsDirectives({
+    html,
+    xRobotsTag: response.headers.get('x-robots-tag'),
+  });
+
+  if (hasBlockingRobotsDirective(directives)) {
+    return {
+      directives,
+      reason: 'robots',
+      url,
+    };
+  }
+
+  return {
+    directives,
+    url,
+  };
+}
+
+function dedupe(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const sitemapUrl = options.sitemapUrl ?? `${baseUrl}/sitemap.xml`;
+  const host = new URL(baseUrl).host;
+  const rawSitemapUrls = parseSitemapUrls(await fetchText(sitemapUrl));
+  const hostUrls = dedupe(
+    rawSitemapUrls.filter((item) => new URL(item).host === host)
+  );
+
+  const inspections: InspectionResult[] = [];
+
+  for (const url of hostUrls) {
+    inspections.push(await inspectUrl(url, host));
+  }
+
+  const urlList = inspections
+    .filter((item) => !item.reason)
+    .map((item) => item.url);
+  const skipped = inspections.filter((item) => item.reason);
+  const keyLocation = getIndexNowKeyLocation(baseUrl);
+  const payload = {
+    host,
+    key: INDEXNOW_KEY,
+    keyLocation,
+    urlList,
+  };
+
+  console.log(
+    JSON.stringify(
+      {
+        baseUrl,
+        dryRun: options.dryRun,
+        keyLocation,
+        skipped,
+        sitemapUrl,
+        submittedCount: urlList.length,
+        totalSitemapUrls: rawSitemapUrls.length,
+      },
+      null,
+      2
+    )
+  );
+
+  if (!urlList.length) {
+    throw new Error('No indexable URLs remained after filtering');
+  }
+
+  if (options.dryRun) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const response = await fetch(options.endpoint, {
+    body: JSON.stringify(payload),
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+    },
+    method: 'POST',
+  });
+  const body = await response.text();
+
+  console.log(
+    JSON.stringify(
+      {
+        responseBody: body,
+        responseStatus: response.status,
+        responseStatusText: response.statusText,
+      },
+      null,
+      2
+    )
+  );
+
+  if (!response.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    JSON.stringify(
+      {
+        message: error instanceof Error ? error.message : String(error),
+      },
+      null,
+      2
+    )
+  );
+  process.exitCode = 1;
+});

--- a/src/app/72c407d2cd294af1b9fb2817515b8cf5.txt/route.ts
+++ b/src/app/72c407d2cd294af1b9fb2817515b8cf5.txt/route.ts
@@ -1,0 +1,19 @@
+import { INDEXNOW_KEY } from '@/lib/seo/indexnow';
+
+const HEADERS = {
+  'Content-Type': 'text/plain; charset=utf-8',
+};
+
+export function GET(): Response {
+  return new Response(INDEXNOW_KEY, {
+    status: 200,
+    headers: HEADERS,
+  });
+}
+
+export function HEAD(): Response {
+  return new Response(null, {
+    status: 200,
+    headers: HEADERS,
+  });
+}

--- a/src/lib/seo/indexnow.ts
+++ b/src/lib/seo/indexnow.ts
@@ -1,0 +1,99 @@
+const BLOCKING_DIRECTIVES = new Set(['noindex', 'nofollow', 'none']);
+
+export const INDEXNOW_KEY = '72c407d2cd294af1b9fb2817515b8cf5';
+export const INDEXNOW_KEY_PATH = `/${INDEXNOW_KEY}.txt`;
+export const INDEXNOW_ENDPOINT = 'https://api.indexnow.org/indexnow';
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '');
+}
+
+export function getIndexNowKeyLocation(baseUrl: string): string {
+  return `${normalizeBaseUrl(baseUrl)}${INDEXNOW_KEY_PATH}`;
+}
+
+export function parseSitemapUrls(xml: string): string[] {
+  return Array.from(xml.matchAll(/<loc>(.*?)<\/loc>/g)).map(([, url]) =>
+    decodeXmlEntities(url.trim())
+  );
+}
+
+export function hasBlockingRobotsDirective(directives: string[]): boolean {
+  return directives.some((directive) => BLOCKING_DIRECTIVES.has(directive));
+}
+
+export function extractRobotsDirectives({
+  html,
+  xRobotsTag,
+}: {
+  html?: string;
+  xRobotsTag?: string | null;
+}): string[] {
+  const directives = new Set<string>();
+
+  addDirectiveList(directives, xRobotsTag);
+
+  if (!html) {
+    return Array.from(directives);
+  }
+
+  for (const tag of html.match(/<meta\b[^>]*>/gi) ?? []) {
+    const name = getMetaAttribute(tag, 'name')?.toLowerCase();
+    const content = getMetaAttribute(tag, 'content');
+
+    if (!name || !content) {
+      continue;
+    }
+
+    if (!name.includes('robots') && !name.endsWith('bot')) {
+      continue;
+    }
+
+    addDirectiveList(directives, content);
+  }
+
+  return Array.from(directives);
+}
+
+function addDirectiveList(target: Set<string>, rawValue?: string | null): void {
+  if (!rawValue) {
+    return;
+  }
+
+  rawValue
+    .split(',')
+    .map((directive) => directive.trim().toLowerCase())
+    .filter(Boolean)
+    .forEach((directive) => target.add(directive));
+}
+
+function getMetaAttribute(tag: string, attribute: string): string | undefined {
+  const doubleQuoted = new RegExp(`${attribute}\\s*=\\s*"([^"]*)"`, 'i').exec(
+    tag
+  );
+
+  if (doubleQuoted) {
+    return doubleQuoted[1];
+  }
+
+  const singleQuoted = new RegExp(`${attribute}\\s*=\\s*'([^']*)'`, 'i').exec(
+    tag
+  );
+
+  if (singleQuoted) {
+    return singleQuoted[1];
+  }
+
+  const unquoted = new RegExp(`${attribute}\\s*=\\s*([^\\s>]+)`, 'i').exec(tag);
+
+  return unquoted?.[1];
+}
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}


### PR DESCRIPTION
## Summary
- add a shared IndexNow helper module and serve the required key file from `/72c407d2cd294af1b9fb2817515b8cf5.txt`
- add `pnpm indexnow:submit` to load sitemap URLs, filter `noindex`/`nofollow` or foreign-host pages, and submit the remaining URLs to `api.indexnow.org`
- submit the current `flowchartai.org` sitemap set and capture that 20 URLs were accepted while `/about`, `/contact`, and `/changelog` were skipped because they are `noindex,nofollow`

## Test Evidence
- `pnpm exec biome check package.json scripts/submit-indexnow.ts src/app/72c407d2cd294af1b9fb2817515b8cf5.txt/route.ts src/lib/seo/indexnow.ts`
- `pnpm exec tsx scripts/submit-indexnow.ts --dry-run --base-url https://flowchartai.org`
- `pnpm exec tsx scripts/submit-indexnow.ts --base-url https://flowchartai.org`
- `curl -sS -D - http://127.0.0.1:3200/72c407d2cd294af1b9fb2817515b8cf5.txt -o -`
- `pnpm build`

## Deployment Considerations
- production `https://flowchartai.org/72c407d2cd294af1b9fb2817515b8cf5.txt` still returns `404` until this PR is merged and deployed
- the IndexNow POST already returned `202 Accepted`, which means the URL batch was received and key validation is still pending key-file availability
- follow-up tracking: GitHub issue #11, Linear TAN-165

Linear: TAN-150