### PR TITLE
fix: 排除显式 noindex 的营销页面 sitemap 条目

### DIFF
--- a/src/app/[locale]/(marketing)/(pages)/about/page.tsx
+++ b/src/app/[locale]/(marketing)/(pages)/about/page.tsx
@@ -3,6 +3,7 @@ import { BlurFadeDemo } from '@/components/magicui/example/blur-fade-example';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { websiteConfig } from '@/config/website';
+import { isExplicitlyNoIndexMarketingPage } from '@/lib/marketing-page-indexing';
 import { constructMetadata } from '@/lib/metadata';
 import { getUrlWithLocale } from '@/lib/urls/urls';
 import { cn } from '@/lib/utils';
@@ -24,7 +25,7 @@ export async function generateMetadata({
     title: pt('title') + ' | ' + t('title'),
     description: pt('description'),
     canonicalUrl: getUrlWithLocale('/about', locale),
-    noIndex: true,
+    noIndex: isExplicitlyNoIndexMarketingPage('/about'),
   });
 }
 

--- a/src/app/[locale]/(marketing)/(pages)/changelog/page.tsx
+++ b/src/app/[locale]/(marketing)/(pages)/changelog/page.tsx
@@ -1,4 +1,5 @@
 import { ReleaseCard } from '@/components/release/release-card';
+import { isExplicitlyNoIndexMarketingPage } from '@/lib/marketing-page-indexing';
 import { constructMetadata } from '@/lib/metadata';
 import { getReleases } from '@/lib/release/get-releases';
 import { getUrlWithLocale } from '@/lib/urls/urls';
@@ -24,7 +25,7 @@ export async function generateMetadata({
     title: pt('title') + ' | ' + t('title'),
     description: pt('description'),
     canonicalUrl: getUrlWithLocale('/changelog', locale),
-    noIndex: true,
+    noIndex: isExplicitlyNoIndexMarketingPage('/changelog'),
   });
 }
 

--- a/src/app/[locale]/(marketing)/(pages)/contact/page.tsx
+++ b/src/app/[locale]/(marketing)/(pages)/contact/page.tsx
@@ -1,5 +1,6 @@
 import { ContactFormCard } from '@/components/contact/contact-form-card';
 import Container from '@/components/layout/container';
+import { isExplicitlyNoIndexMarketingPage } from '@/lib/marketing-page-indexing';
 import { constructMetadata } from '@/lib/metadata';
 import { getUrlWithLocale } from '@/lib/urls/urls';
 import type { Metadata } from 'next';
@@ -19,7 +20,7 @@ export async function generateMetadata({
     title: pt('title') + ' | ' + t('title'),
     description: pt('description'),
     canonicalUrl: getUrlWithLocale('/contact', locale),
-    noIndex: true,
+    noIndex: isExplicitlyNoIndexMarketingPage('/contact'),
   });
 }
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import { websiteConfig } from '@/config/website';
 import { getLocalePathname } from '@/i18n/navigation';
 import { routing } from '@/i18n/routing';
 import { source } from '@/lib/docs/source';
+import { isExplicitlyNoIndexMarketingPage } from '@/lib/marketing-page-indexing';
 import { allPosts } from 'content-collections';
 import type { MetadataRoute } from 'next';
 import type { Locale } from 'next-intl';
@@ -37,7 +38,9 @@ function getEnabledStaticRoutes(): string[] {
     conditionalRoutes.push('/ai/text', '/ai/image', '/ai/video', '/ai/audio');
   }
 
-  return [...baseRoutes, ...conditionalRoutes];
+  return [...baseRoutes, ...conditionalRoutes].filter(
+    (route) => !isExplicitlyNoIndexMarketingPage(route)
+  );
 }
 
 /**
@@ -68,9 +71,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       } else if (route === '/blog') {
         priority = 0.8; // high priority for blog main page
         changeFrequency = 'daily';
-      } else if (route === '/about' || route === '/contact') {
-        priority = 0.7; // medium priority for info pages
-        changeFrequency = 'monthly';
       } else if (
         route.includes('/privacy') ||
         route.includes('/terms') ||

--- a/src/lib/marketing-page-indexing.ts
+++ b/src/lib/marketing-page-indexing.ts
@@ -1,0 +1,27 @@
+export const EXPLICITLY_NOINDEX_MARKETING_PAGES = [
+  '/about',
+  '/contact',
+  '/changelog',
+] as const;
+
+type ExplicitlyNoIndexMarketingPage =
+  (typeof EXPLICITLY_NOINDEX_MARKETING_PAGES)[number];
+
+const explicitlyNoIndexMarketingPageSet =
+  new Set<ExplicitlyNoIndexMarketingPage>(EXPLICITLY_NOINDEX_MARKETING_PAGES);
+
+export function isExplicitlyNoIndexMarketingPage(pathname: string): boolean {
+  const normalizedPath = normalizePathname(pathname);
+
+  return explicitlyNoIndexMarketingPageSet.has(
+    normalizedPath as ExplicitlyNoIndexMarketingPage
+  );
+}
+
+function normalizePathname(pathname: string): string {
+  if (!pathname || pathname === '/') {
+    return '/';
+  }
+
+  return pathname.replace(/\/+$/, '');
+}


### PR DESCRIPTION
## Summary
- 复用一份显式 noindex 营销页名单，给 sitemap 和页面 metadata 共用
- 从 sitemap 静态路由中过滤 /about、/contact、/changelog
- 保持这三个页面继续输出 noindex, nofollow

## Validation
- `curl -s https://flowchartai.org/sitemap.xml | rg -n "/about|/contact|/changelog"`
- `pnpm exec biome check src/app/sitemap.ts 'src/app/[locale]/(marketing)/(pages)/about/page.tsx' 'src/app/[locale]/(marketing)/(pages)/contact/page.tsx' 'src/app/[locale]/(marketing)/(pages)/changelog/page.tsx' src/lib/marketing-page-indexing.ts`\n- `pnpm build`\n- `curl -s http://127.0.0.1:3101/sitemap.xml | rg -n "/about|/contact|/changelog|/pricing|/blog"`\n- `curl -sL http://127.0.0.1:3101/about | grep -o '<meta name="robots" content="[^\"]*"' | head -n 1`\n- `curl -sL http://127.0.0.1:3101/contact | grep -o '<meta name="robots" content="[^\"]*"' | head -n 1`\n- `curl -sL http://127.0.0.1:3101/changelog | grep -o '<meta name="robots" content="[^\"]*"' | head -n 1`\n- `curl -sL http://127.0.0.1:3101/pricing | grep -o '<meta name="robots" content="[^\"]*"' | head -n 1`\n\nRefs TAN-165